### PR TITLE
Enable nullable inputs for default switch

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -146,4 +146,29 @@ describe("$switch.default", () => {
     expect(skullEmoji).toBe(Emojis["💀"]);
     expect(skullEmoji === Emojis["💀"]).toBeTruthy();
   });
+
+  test("with null input", () => {
+    enum Emotions {
+      sad,
+      happy,
+      dead,
+    }
+    enum Emojis {
+      "😢",
+      "😄",
+      "💀",
+      "💩",
+    }
+    const skullEmoji: Emojis = $switch(
+      undefined,
+      {
+        [Emotions.happy]: () => Emojis["😄"],
+        [Emotions.dead]: () => Emojis["💀"],
+      },
+      () => Emojis["💩"]
+    );
+
+    expect(skullEmoji).toBe(Emojis["💩"]);
+    expect(skullEmoji === Emojis["💩"]).toBeTruthy();
+  });
 });

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -147,7 +147,7 @@ describe("$switch.default", () => {
     expect(skullEmoji === Emojis["💀"]).toBeTruthy();
   });
 
-  test("with null input", () => {
+  test("with undefined input", () => {
     enum Emotions {
       sad,
       happy,
@@ -161,6 +161,31 @@ describe("$switch.default", () => {
     }
     const skullEmoji: Emojis = $switch(
       undefined,
+      {
+        [Emotions.happy]: () => Emojis["😄"],
+        [Emotions.dead]: () => Emojis["💀"],
+      },
+      () => Emojis["💩"]
+    );
+
+    expect(skullEmoji).toBe(Emojis["💩"]);
+    expect(skullEmoji === Emojis["💩"]).toBeTruthy();
+  });
+
+  test("with null input", () => {
+    enum Emotions {
+      sad,
+      happy,
+      dead,
+    }
+    enum Emojis {
+      "😢",
+      "😄",
+      "💀",
+      "💩",
+    }
+    const skullEmoji: Emojis = $switch(
+      null,
       {
         [Emotions.happy]: () => Emojis["😄"],
         [Emotions.dead]: () => Emojis["💀"],

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,14 +20,14 @@ export function $switchCaseDefault<K extends string | number, V>(
   cases: { [k in K]?: () => V },
   defaultCase: () => V
 ): V {
-  if (input) {
+  if (input === undefined || input === null) {
+    const value = defaultCase();
+    return value;
+  } else {
     const candidate = cases[input];
     return candidate 
       ? candidate()
       : defaultCase();
-  } else {
-    const value = defaultCase();
-    return value;
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,14 +16,15 @@ export function $switchCaseStrict<K extends string | number, V>(
 }
 
 export function $switchCaseDefault<K extends string | number, V>(
-  input: K,
+  input: K | null | undefined,
   cases: { [k in K]?: () => V },
   defaultCase: () => V
 ): V {
-  const candidate = cases[input];
-  if (candidate) {
-    const value = candidate();
-    return value;
+  if (input) {
+    const candidate = cases[input];
+    return candidate 
+      ? candidate()
+      : defaultCase();
   } else {
     const value = defaultCase();
     return value;


### PR DESCRIPTION
### What changes

Enables nullable inputs for `$switch.default` for convenience of optional types.